### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # solidworks-makra
-export inport dat
+Export and import data


### PR DESCRIPTION
## Summary
- fix a typo in the README so it reads "Export and import data"

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684aa0180c508330bf2c14c0abc1922a