### PR TITLE
Add simple MQL5 trading system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # solidworks-makra
-export inport dat
+
+This repository contains various automation scripts. The `mql5` directory includes example code for MetaTrader 5 trading systems.
+
+## Included Trading Systems
+
+`MovingAverageCrossEA.mq5` demonstrates a moving-average crossover strategy.
+`RoundLevelOrdersEA.mq5` places pending orders around user-defined round price levels.

--- a/mql5/MovingAverageCrossEA.mq5
+++ b/mql5/MovingAverageCrossEA.mq5
@@ -1,0 +1,70 @@
+#property strict
+#property description "Simple Moving Average Cross Expert Advisor"
+
+input int FastMAPeriod = 10;       // Fast MA period
+input int SlowMAPeriod = 25;       // Slow MA period
+input double LotSize     = 0.1;    // Trade lot size
+
+int fast_ma_handle;
+int slow_ma_handle;
+
+int OnInit()
+{
+    fast_ma_handle = iMA(_Symbol, _Period, FastMAPeriod, 0, MODE_EMA, PRICE_CLOSE);
+    slow_ma_handle = iMA(_Symbol, _Period, SlowMAPeriod, 0, MODE_EMA, PRICE_CLOSE);
+    if(fast_ma_handle == INVALID_HANDLE || slow_ma_handle == INVALID_HANDLE)
+        return(INIT_FAILED);
+    return(INIT_SUCCEEDED);
+}
+
+void OnDeinit(const int reason)
+{
+    if(fast_ma_handle != INVALID_HANDLE)
+        IndicatorRelease(fast_ma_handle);
+    if(slow_ma_handle != INVALID_HANDLE)
+        IndicatorRelease(slow_ma_handle);
+}
+
+void OnTick()
+{
+    double fast_ma[2];
+    double slow_ma[2];
+
+    if(CopyBuffer(fast_ma_handle,0,0,2,fast_ma)<=0)
+        return;
+    if(CopyBuffer(slow_ma_handle,0,0,2,slow_ma)<=0)
+        return;
+
+    double fast_prev = fast_ma[1];
+    double slow_prev = slow_ma[1];
+    double fast_curr = fast_ma[0];
+    double slow_curr = slow_ma[0];
+
+    if(!PositionSelect(_Symbol))
+    {
+        if(fast_prev < slow_prev && fast_curr > slow_curr)
+            TradePosition(ORDER_TYPE_BUY);
+        else if(fast_prev > slow_prev && fast_curr < slow_curr)
+            TradePosition(ORDER_TYPE_SELL);
+    }
+}
+
+void TradePosition(const ENUM_ORDER_TYPE type)
+{
+    MqlTradeRequest request;
+    MqlTradeResult  result;
+    ZeroMemory(request);
+    ZeroMemory(result);
+
+    request.action      = TRADE_ACTION_DEAL;
+    request.symbol      = _Symbol;
+    request.volume      = LotSize;
+    request.type        = type;
+    request.price       = (type==ORDER_TYPE_BUY) ? SymbolInfoDouble(_Symbol,SYMBOL_ASK)
+                                                : SymbolInfoDouble(_Symbol,SYMBOL_BID);
+    request.deviation   = 10;
+    request.magic       = 123456;
+    request.type_filling= ORDER_FILLING_FOK;
+
+    OrderSend(request, result);
+}

--- a/mql5/RoundLevelOrdersEA.mq5
+++ b/mql5/RoundLevelOrdersEA.mq5
@@ -1,0 +1,68 @@
+#property strict
+#property description "Trades predefined round levels using limit or stop orders"
+
+input string LevelList = "1.1000,1.2000"; // comma-separated levels
+input double LotSize = 0.1;               // trade volume
+input int    Deviation = 10;              // slippage in points
+input ulong  Magic = 987654;              // magic number for orders
+
+double Levels[];
+int    LevelCount;
+
+int OnInit()
+{
+    LevelCount = StringSplit(LevelList, ',', Levels);
+    return (LevelCount > 0) ? INIT_SUCCEEDED : INIT_PARAMETERS_INCORRECT;
+}
+
+bool HasPendingAtLevel(double level)
+{
+    for(int i=0;i<OrdersTotal();++i)
+    {
+        if(OrderGetTicket(i) &&
+           OrderGetInteger(ORDER_TYPE) != ORDER_TYPE_BUY &&
+           OrderGetInteger(ORDER_TYPE) != ORDER_TYPE_SELL)
+        {
+            if(OrderGetString(ORDER_SYMBOL)==_Symbol &&
+               OrderGetInteger(ORDER_MAGIC)==(long)Magic &&
+               MathAbs(OrderGetDouble(ORDER_PRICE_OPEN)-level) <= _Point)
+                return true;
+        }
+    }
+    return false;
+}
+
+void PlacePending(double level)
+{
+    if(HasPendingAtLevel(level))
+        return;
+
+    MqlTradeRequest request;
+    MqlTradeResult  result;
+    ZeroMemory(request);
+    ZeroMemory(result);
+
+    request.action      = TRADE_ACTION_PENDING;
+    request.symbol      = _Symbol;
+    request.volume      = LotSize;
+    request.price       = level;
+    request.deviation   = Deviation;
+    request.magic       = Magic;
+    request.type_time   = ORDER_TIME_GTC;
+    request.type_filling= ORDER_FILLING_FOK;
+    request.comment     = "Level "+DoubleToString(level, _Digits);
+
+    double ask = SymbolInfoDouble(_Symbol, SYMBOL_ASK);
+    if(ask > level)
+        request.type = ORDER_TYPE_BUY_LIMIT;
+    else
+        request.type = ORDER_TYPE_BUY_STOP;
+
+    OrderSend(request, result);
+}
+
+void OnTick()
+{
+    for(int i=0;i<LevelCount;++i)
+        PlacePending(Levels[i]);
+}


### PR DESCRIPTION
## Summary
- add a basic Moving Average Cross expert advisor in MQL5
- document the new trading system in the README
- add an EA that keeps pending orders around user-specified round levels

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d90a35bb08330a544a65cb2874a6c